### PR TITLE
feat: v2.0 — Sidebar mode, in-app settings overlay, search performance & UI refresh

### DIFF
--- a/bookmark/background.js
+++ b/bookmark/background.js
@@ -1,0 +1,134 @@
+// Service worker that keeps popup and sidebar modes mutually exclusive.
+// Mode is persisted in chrome.storage.local so it survives browser restarts.
+
+const MODE_KEY = "MAPLE_DISPLAY_MODE";
+const MODE_POPUP = "popup";
+const MODE_SIDEBAR = "sidebar";
+const POPUP_PATH = "popup.html";
+
+async function getStoredMode() {
+  try {
+    const result = await chrome.storage.local.get(MODE_KEY);
+    return result[MODE_KEY] === MODE_SIDEBAR ? MODE_SIDEBAR : MODE_POPUP;
+  } catch {
+    return MODE_POPUP;
+  }
+}
+
+async function applyMode(mode) {
+  const isSidebar = mode === MODE_SIDEBAR;
+
+  try {
+    await chrome.action.setPopup({ popup: isSidebar ? "" : POPUP_PATH });
+  } catch (e) {
+    console.warn("Failed to set popup:", e);
+  }
+
+  if (chrome.sidePanel?.setPanelBehavior) {
+    try {
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: isSidebar });
+    } catch (e) {
+      console.warn("Failed to set side panel behavior:", e);
+    }
+  }
+}
+
+// Firefox 不支持 chrome.sidePanel，使用 sidebarAction 兜底：popup 关闭时点击 action 打开侧边栏。
+chrome.action.onClicked.addListener(async () => {
+  if (chrome.sidePanel) return; // Chromium 已通过 setPanelBehavior 处理
+  const sidebarApi = globalThis.browser?.sidebarAction;
+  if (sidebarApi?.open) {
+    try {
+      await sidebarApi.open();
+    } catch (e) {
+      console.warn("Failed to open Firefox sidebar:", e);
+    }
+  }
+});
+
+async function init() {
+  const mode = await getStoredMode();
+  await applyMode(mode);
+}
+
+chrome.runtime.onInstalled.addListener(init);
+chrome.runtime.onStartup.addListener(init);
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || message.type !== "MAPLE_SET_MODE") {
+    return false;
+  }
+
+  const nextMode = message.mode === MODE_SIDEBAR ? MODE_SIDEBAR : MODE_POPUP;
+
+  (async () => {
+    await chrome.storage.local.set({ [MODE_KEY]: nextMode });
+    await applyMode(nextMode);
+
+    if (message.openImmediately) {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+      if (nextMode === MODE_SIDEBAR) {
+        try {
+          if (chrome.sidePanel?.open && tab) {
+            await chrome.sidePanel.open({ windowId: tab.windowId });
+          } else {
+            const sidebarApi = globalThis.browser?.sidebarAction;
+            if (sidebarApi?.open) {
+              await sidebarApi.open();
+            }
+          }
+        } catch (e) {
+          console.warn("Failed to open side panel:", e);
+        }
+      } else if (nextMode === MODE_POPUP) {
+        // Sidebar -> popup geçişi: önce action.openPopup dene (Chrome 127+),
+        // başarısız olursa standalone popup penceresi aç (her Chrome sürümünde çalışır).
+        let opened = false;
+        try {
+          if (chrome.action?.openPopup) {
+            await chrome.action.openPopup();
+            opened = true;
+          }
+        } catch (e) {
+          console.warn("chrome.action.openPopup failed, falling back:", e);
+        }
+
+        if (!opened) {
+          try {
+            const w = tab ? await chrome.windows.get(tab.windowId) : null;
+            const popupWidth = 420;
+            const popupHeight = 540;
+            const left = w ? Math.max(0, (w.left || 0) + (w.width || 800) - popupWidth - 24) : undefined;
+            const top = w ? (w.top || 0) + 80 : undefined;
+            await chrome.windows.create({
+              url: chrome.runtime.getURL("popup.html"),
+              type: "popup",
+              width: popupWidth,
+              height: popupHeight,
+              focused: true,
+              ...(left !== undefined ? { left } : {}),
+              ...(top !== undefined ? { top } : {}),
+            });
+          } catch (e) {
+            console.warn("Failed to open popup window fallback:", e);
+          }
+        }
+
+        // Firefox sidebar'ı için açıkça kapat
+        try {
+          const sidebarApi = globalThis.browser?.sidebarAction;
+          if (sidebarApi?.close) {
+            await sidebarApi.close();
+          }
+        } catch (e) {
+          console.warn("Failed to close Firefox sidebar:", e);
+        }
+      }
+    }
+
+    sendResponse({ ok: true, mode: nextMode });
+  })();
+
+  return true;
+});

--- a/bookmark/manifest.json
+++ b/bookmark/manifest.json
@@ -2,9 +2,15 @@
   "manifest_version": 3,
   "name": "Maple Bookmarks",
   "description": "Let you navigate smoothly while hiding the bookmark bar.",
-  "version": "1.18",
+  "version": "2.0",
   "action": {
     "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "side_panel": {
+    "default_path": "sidebar.html"
   },
   "commands": {
     "_execute_action": {
@@ -15,7 +21,7 @@
     }
   },
   "optional_host_permissions": ["*://*/*"],
-  "permissions": ["bookmarks", "favicon"],
+  "permissions": ["bookmarks", "favicon", "sidePanel", "storage"],
   "options_page": "settings.html",
   "icons": {
     "16": "logo.png",

--- a/bookmark/manifest_firefox.json
+++ b/bookmark/manifest_firefox.json
@@ -2,9 +2,17 @@
   "manifest_version": 3,
   "name": "Maple Bookmarks",
   "description": "Let you navigate smoothly while hiding the bookmark bar.",
-  "version": "1.18",
+  "version": "2.0",
   "action": {
     "default_popup": "popup.html"
+  },
+  "sidebar_action": {
+    "default_panel": "sidebar.html",
+    "default_title": "Maple Bookmarks",
+    "default_icon": "logo.png"
+  },
+  "background": {
+    "scripts": ["background.js"]
   },
   "commands": {
     "_execute_action": {
@@ -19,7 +27,7 @@
     }
   },
   "optional_host_permissions": ["*://*/*"],
-  "permissions": ["bookmarks", "favicon"],
+  "permissions": ["bookmarks", "favicon", "storage"],
   "options_page": "settings.html",
   "icons": {
     "16": "logo.png",

--- a/bookmark/popup.js
+++ b/bookmark/popup.js
@@ -1,14 +1,6 @@
 import Fuse from "./lib/fuse.js";
 import { debounce } from "./utils/debounce.js";
-import {
-  keyText,
-  BestMatchTitle,
-  LastBestMatch,
-  BestMatch,
-  EmptyBookmarkMessage,
-  ShowSearchWrapper,
-  HideSearchWrapper,
-} from "./utils/i18n.js";
+import { keyText, BestMatchTitle, LastBestMatch, BestMatch, EmptyBookmarkMessage } from "./utils/i18n.js";
 import { Notification } from "./utils/notification.js";
 import { createElement } from "./utils/element.js";
 import { getFavicon } from "./utils/favicon.js";
@@ -21,19 +13,32 @@ const SETTINGS_KEYS = {
   KEEP_PANEL_OPEN: "MAPLE_KEEP_PANEL_OPEN",
 };
 
-const FUSE_OPTIONS = {
-  keys: ["title", "url"],
-  ignoreLocation: false,
-  includeScore: true,
-  threshold: 0.5,
-  shouldSort: true,
-};
-
 const HAS_SEEN_SETTINGS_HINT_KEY = "MAPLE_SETTINGS_HINT_SEEN";
+const FIXED_POPUP_WIDTH = 408;
+const FIXED_POPUP_HEIGHT = 520;
+// MV3 CSP inline script'leri engelliyor; modu URL pathname'den tespit ediyoruz
+const IS_SIDEBAR_MODE = typeof location !== "undefined" && /sidebar\.html$/.test(location.pathname || "");
 
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
+function applyFixedPopupSize() {
+  if (IS_SIDEBAR_MODE) return;
+  document.documentElement.style.width = `${FIXED_POPUP_WIDTH}px`;
+  document.documentElement.style.minWidth = `${FIXED_POPUP_WIDTH}px`;
+  document.documentElement.style.maxWidth = `${FIXED_POPUP_WIDTH}px`;
+  document.documentElement.style.height = `${FIXED_POPUP_HEIGHT}px`;
+  document.documentElement.style.minHeight = `${FIXED_POPUP_HEIGHT}px`;
+  document.documentElement.style.maxHeight = `${FIXED_POPUP_HEIGHT}px`;
+
+  if (document.body) {
+    document.body.style.width = `${FIXED_POPUP_WIDTH}px`;
+    document.body.style.minWidth = `${FIXED_POPUP_WIDTH}px`;
+    document.body.style.maxWidth = `${FIXED_POPUP_WIDTH}px`;
+    document.body.style.height = `${FIXED_POPUP_HEIGHT}px`;
+    document.body.style.minHeight = `${FIXED_POPUP_HEIGHT}px`;
+    document.body.style.maxHeight = `${FIXED_POPUP_HEIGHT}px`;
+  }
 }
+
+applyFixedPopupSize();
 
 // 获取搜索功能开启状态
 function isSearchEnabled() {
@@ -55,114 +60,20 @@ function isKeepPanelOpenEnabled() {
   return localStorage.getItem(SETTINGS_KEYS.KEEP_PANEL_OPEN) === "true";
 }
 
-function getSearchHiddenState() {
-  if (!isSearchEnabled()) {
-    return true;
-  }
-  return localStorage.getItem("SHOW_SEARCH_BAR") !== "true";
-}
-
-function getPersistedHeader() {
-  const persistedHeader = localStorage.getItem("persistedHeader");
-  if (!persistedHeader) {
-    return null;
-  }
-
-  try {
-    const parsedHeader = JSON.parse(persistedHeader);
-    if (!Array.isArray(parsedHeader) || parsedHeader.length === 0) {
-      return null;
-    }
-    return parsedHeader;
-  } catch {
-    return null;
-  }
-}
-
-function clearBestMatches({ clearPersisted = false } = {}) {
-  const bestMatchContainer = document.querySelector("#best-match");
-  if (bestMatchContainer) {
-    bestMatchContainer.innerHTML = "";
-  }
-  bestMatches = [];
-  activeBestMatchIndex = 0;
-
-  if (clearPersisted) {
-    localStorage.removeItem("persistedHeader");
-  }
-}
-
-function restorePersistedHeader() {
-  const persistedHeader = getPersistedHeader();
-  if (persistedHeader) {
-    updateHeader(persistedHeader, true);
-  } else {
-    clearBestMatches();
-  }
-}
-
 function createTab(url, active = true) {
   if (typeof browser !== "undefined") {
-    return browser.tabs.create({ url, active });
+    browser.tabs.create({ url, active });
+  } else {
+    chrome.tabs.create({ url, active });
   }
-
-  if (typeof chrome !== "undefined" && chrome.tabs?.create) {
-    return new Promise((resolve, reject) => {
-      chrome.tabs.create({ url, active }, (tab) => {
-        const runtimeError = chrome.runtime?.lastError;
-        if (runtimeError) {
-          reject(new Error(runtimeError.message));
-          return;
-        }
-        resolve(tab);
-      });
-    });
-  }
-
-  return Promise.resolve(window.open(url, "_blank"));
 }
 
 function updateCurrentTab(url) {
   if (typeof browser !== "undefined") {
-    return browser.tabs.update({ url });
+    browser.tabs.update({ url });
+  } else {
+    chrome.tabs.update({ url });
   }
-
-  if (typeof chrome !== "undefined" && chrome.tabs?.update) {
-    return new Promise((resolve, reject) => {
-      chrome.tabs.update({ url }, (tab) => {
-        const runtimeError = chrome.runtime?.lastError;
-        if (runtimeError) {
-          reject(new Error(runtimeError.message));
-          return;
-        }
-        resolve(tab);
-      });
-    });
-  }
-
-  window.location.href = url;
-  return Promise.resolve();
-}
-
-function getBookmarkTree() {
-  if (typeof browser !== "undefined") {
-    return browser.bookmarks.getTree();
-  }
-
-  if (typeof chrome !== "undefined" && chrome.bookmarks?.getTree) {
-    return new Promise((resolve, reject) => {
-      chrome.bookmarks.getTree((tree) => {
-        const runtimeError = chrome.runtime?.lastError;
-        if (runtimeError) {
-          reject(new Error(runtimeError.message));
-          return;
-        }
-        resolve(tree);
-      });
-    });
-  }
-
-  return Promise.reject(new Error("Bookmarks API is unavailable"));
 }
 
 const CLASS_NAMES = {
@@ -177,79 +88,190 @@ const CLASS_NAMES = {
 let folderCount;
 
 let searchInput = document.getElementById("searchInput");
-let hideArrow = document.querySelector(".search-action");
-let hideArrowIcon = document.querySelector(".search-action i");
 let hotArea = document.querySelector("#hot-area");
 let settingsBtn = document.getElementById("settingsBtn");
 let settingsWrapper = document.querySelector(".settings-wrapper");
+let modeBtn = document.getElementById("modeBtn");
 
 let activeBestMatchIndex = 0;
 let hideTimeout = null;
-let searchIndex = [];
-let searchFuse = null;
-let searchFolders = [];
+// Search açıkken hem popup hem sidebar'da hep görünür olsun
+let searchIsHide = !isSearchEnabled();
+
 let bestMatches = [];
-let searchIsHide = getSearchHiddenState();
-let isPopupInitialized = false;
-let isPopupInitializing = false;
-let hasBoundHotAreaHover = false;
-
-function shouldFocusSearchInput() {
-  return searchInput && isSearchEnabled() && !searchIsHide;
-}
-
-function focusSearchInput() {
-  if (!shouldFocusSearchInput()) {
-    return;
+// 延迟恢复 header 元素，避免阻塞初始渲染
+setTimeout(() => {
+  if (isSearchEnabled()) {
+    const persistedHeader = localStorage.getItem("persistedHeader");
+    if (persistedHeader) {
+      try {
+        updateHeader(JSON.parse(persistedHeader), true);
+        updateActiveBestMatch(activeBestMatchIndex);
+      } catch {
+        // 忽略解析错误
+      }
+    }
   }
+}, 0);
 
-  searchInput.focus({ preventScroll: true });
-  searchInput.select();
-}
+const isZhUI = navigator.language.startsWith("zh");
 
-function scheduleSearchInputFocus() {
-  focusSearchInput();
-  requestAnimationFrame(focusSearchInput);
-  setTimeout(focusSearchInput, 60);
-}
+// Settings overlay: pop-up + sidebar içinde overlay olarak ayarlar paneli
+const SETTINGS_OVERLAY = {
+  el: null,
+  bookmarksEl: null,
+  init() {
+    this.el = document.getElementById("settings-overlay");
+    this.bookmarksEl = document.getElementById("bookmarks");
+    if (!this.el) return;
 
-async function openOptionsPage() {
-  if (typeof browser !== "undefined" && browser.runtime?.openOptionsPage) {
-    await browser.runtime.openOptionsPage();
-    return;
-  }
-
-  if (typeof chrome !== "undefined" && typeof chrome.runtime?.openOptionsPage === "function") {
-    await new Promise((resolve, reject) => {
-      chrome.runtime.openOptionsPage(() => {
-        const runtimeError = chrome.runtime?.lastError;
-        if (runtimeError) {
-          reject(new Error(runtimeError.message));
-          return;
+    // i18n metinler
+    const i18n = isZhUI
+      ? {
+          title: "设置",
+          back: "返回",
+          "display-mode-title": "显示模式（侧边栏）",
+          "display-mode-desc": "开启后点击图标打开侧边栏，关闭后打开弹窗。",
+          "search-title": "搜索",
+          "search-desc": "显示搜索框以快速查找书签。",
+          "tips-title": "悬停提示",
+          "tips-desc": "鼠标悬停时显示完整书签标题。",
+          "newtab-title": "新标签页打开",
+          "newtab-desc": "在新标签页打开书签，关闭则在当前标签页。",
+          "keep-title": "保持面板",
+          "keep-desc": "在后台标签页打开，让面板保持可见。",
         }
-        resolve();
-      });
+      : {
+          title: "Settings",
+          back: "Back",
+          "display-mode-title": "Display Mode (Sidebar)",
+          "display-mode-desc": "When on, clicking the icon opens the sidebar; when off, it opens the popup.",
+          "search-title": "Search",
+          "search-desc": "Show search box to quickly find bookmarks.",
+          "tips-title": "Hover Tooltips",
+          "tips-desc": "Show full bookmark titles on hover.",
+          "newtab-title": "Open in New Tab",
+          "newtab-desc": "Open bookmarks in a new tab vs the current one.",
+          "keep-title": "Keep Panel Open",
+          "keep-desc": "Open in background tabs to keep the panel visible.",
+        };
+    const titleEl = document.getElementById("settingsOverlayTitle");
+    if (titleEl) titleEl.textContent = i18n.title;
+    const backEl = document.getElementById("settingsOverlayBack");
+    if (backEl) backEl.setAttribute("aria-label", i18n.back);
+    this.el.querySelectorAll("[data-setting-key]").forEach((node) => {
+      const key = node.getAttribute("data-setting-key");
+      if (i18n[key]) node.textContent = i18n[key];
     });
-    return;
-  }
 
-  window.open("settings.html", "_blank");
-}
+    if (backEl) backEl.addEventListener("click", () => this.close());
 
-// 设置按钮事件监听
+    const sidebar = document.getElementById("overlaySidebarMode");
+    const search = document.getElementById("overlaySearchEnabled");
+    const tips = document.getElementById("overlayTipsEnabled");
+    const newtab = document.getElementById("overlayOpenInNewTab");
+    const keep = document.getElementById("overlayKeepPanelOpen");
+
+    if (sidebar) {
+      sidebar.addEventListener("change", () => {
+        const desiredSidebar = sidebar.checked;
+        // Eğer hedef zaten mevcut moddaysa hiçbir şey yapma
+        if (desiredSidebar === IS_SIDEBAR_MODE) return;
+        // Mode-btn ile aynı flow'u tetikle (window.close + popup-window açma fallback'leriyle)
+        if (modeBtn) {
+          modeBtn.click();
+        } else {
+          try {
+            chrome.runtime.sendMessage({
+              type: "MAPLE_SET_MODE",
+              mode: desiredSidebar ? "sidebar" : "popup",
+              openImmediately: true,
+            });
+          } catch (err) {
+            console.error("Failed to update mode:", err);
+          }
+        }
+      });
+    }
+    if (search) {
+      search.addEventListener("change", () => {
+        localStorage.setItem(SETTINGS_KEYS.SEARCH_ENABLED, search.checked.toString());
+        location.reload();
+      });
+    }
+    if (tips) {
+      tips.addEventListener("change", () => {
+        localStorage.setItem(SETTINGS_KEYS.TIPS_ENABLED, tips.checked.toString());
+      });
+    }
+    if (newtab) {
+      newtab.addEventListener("change", () => {
+        localStorage.setItem(SETTINGS_KEYS.OPEN_IN_NEW_TAB, newtab.checked.toString());
+      });
+    }
+    if (keep) {
+      keep.addEventListener("change", () => {
+        localStorage.setItem(SETTINGS_KEYS.KEEP_PANEL_OPEN, keep.checked.toString());
+      });
+    }
+
+    // ESC ile kapat
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && this.el && !this.el.hidden && this.el.classList.contains("open")) {
+        e.preventDefault();
+        this.close();
+      }
+    });
+  },
+  open() {
+    if (!this.el) return;
+    // Mevcut değerleri yükle
+    const search = document.getElementById("overlaySearchEnabled");
+    const tips = document.getElementById("overlayTipsEnabled");
+    const newtab = document.getElementById("overlayOpenInNewTab");
+    const keep = document.getElementById("overlayKeepPanelOpen");
+    const sidebar = document.getElementById("overlaySidebarMode");
+
+    if (search) search.checked = localStorage.getItem(SETTINGS_KEYS.SEARCH_ENABLED) === "true";
+    if (tips) tips.checked = localStorage.getItem(SETTINGS_KEYS.TIPS_ENABLED) === "true";
+    if (newtab) newtab.checked = localStorage.getItem(SETTINGS_KEYS.OPEN_IN_NEW_TAB) !== "false";
+    if (keep) keep.checked = localStorage.getItem(SETTINGS_KEYS.KEEP_PANEL_OPEN) === "true";
+    if (sidebar) {
+      sidebar.checked = IS_SIDEBAR_MODE;
+      try {
+        chrome.storage?.local?.get?.("MAPLE_DISPLAY_MODE", (result) => {
+          if (result && typeof result.MAPLE_DISPLAY_MODE !== "undefined") {
+            sidebar.checked = result.MAPLE_DISPLAY_MODE === "sidebar";
+          }
+        });
+      } catch {
+        // ignore
+      }
+    }
+
+    this.el.hidden = false;
+    requestAnimationFrame(() => {
+      if (this.el) this.el.classList.add("open");
+    });
+  },
+  close() {
+    if (!this.el) return;
+    this.el.classList.remove("open");
+    setTimeout(() => {
+      if (this.el && !this.el.classList.contains("open")) this.el.hidden = true;
+    }, 280);
+  },
+};
+SETTINGS_OVERLAY.init();
+
+// Settings butonu artık ayrı bir sayfa açmıyor — overlay'i açıyor
 if (settingsBtn) {
-  // 设置国际化文本
-  const browserLanguage = navigator.language.startsWith("zh") ? "zh" : "en";
-  const isZh = browserLanguage === "zh";
-  settingsBtn.title = isZh ? "设置" : "Settings";
+  settingsBtn.title = isZhUI ? "设置" : "Settings";
 
   settingsBtn.addEventListener("click", function (e) {
     e.preventDefault();
     e.stopPropagation();
-    openOptionsPage().catch((error) => {
-      console.error("Failed to open settings page:", error);
-      window.open("settings.html", "_blank");
-    });
+    SETTINGS_OVERLAY.open();
   });
 } else {
   console.error("Settings button not found");
@@ -264,6 +286,117 @@ if (settingsWrapper && localStorage.getItem(HAS_SEEN_SETTINGS_HINT_KEY) !== "tru
   }, 1800);
 }
 
+// 监听显示模式变化：如果当前面板与新模式不一致，则自动关闭，避免 popup 与 sidebar 同时显示
+if (typeof chrome !== "undefined" && chrome.storage?.onChanged) {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "local" || !changes.MAPLE_DISPLAY_MODE) return;
+    const newMode = changes.MAPLE_DISPLAY_MODE.newValue;
+    const currentIsSidebar = IS_SIDEBAR_MODE;
+    const newIsSidebar = newMode === "sidebar";
+    if (currentIsSidebar !== newIsSidebar) {
+      window.close();
+    }
+  });
+}
+
+// 模式切换按钮：在 popup 与 sidebar 之间切换，确保两者不会同时存在
+if (modeBtn) {
+  const browserLang = navigator.language.startsWith("zh") ? "zh" : "en";
+  const isZhMode = browserLang === "zh";
+  modeBtn.title = IS_SIDEBAR_MODE
+    ? isZhMode
+      ? "切换到弹窗模式"
+      : "Switch to popup"
+    : isZhMode
+      ? "切换到侧边栏模式"
+      : "Switch to sidebar";
+  // Sidebar moddayken popup-benzeri ikon (hedef = popup), popup moddayken sidebar-benzeri ikon
+  modeBtn.textContent = IS_SIDEBAR_MODE ? "🪟" : "▤";
+
+  modeBtn.addEventListener("click", async function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const nextMode = IS_SIDEBAR_MODE ? "popup" : "sidebar";
+
+    // Önce mod state'ini background'a yazmayı bekle (popup config'inin güncellenmesi için)
+    try {
+      await new Promise((resolve) => {
+        try {
+          chrome.runtime.sendMessage(
+            {
+              type: "MAPLE_SET_MODE",
+              mode: nextMode,
+              openImmediately: !IS_SIDEBAR_MODE, // popup→sidebar için background sidePanel.open çağırsın
+            },
+            () => resolve()
+          );
+        } catch {
+          resolve();
+        }
+      });
+    } catch {
+      // ignore
+    }
+
+    // Sidebar → popup geçişi: önce action.openPopup dene (toolbar'a yapışık, URL bar yok),
+    // başarısız olursa konumlu popup window aç
+    if (IS_SIDEBAR_MODE) {
+      let opened = false;
+      try {
+        if (chrome.action?.openPopup) {
+          await chrome.action.openPopup();
+          opened = true;
+        }
+      } catch (error) {
+        console.warn("chrome.action.openPopup failed, falling back to window:", error);
+      }
+
+      if (!opened) {
+        try {
+          if (chrome.windows?.create) {
+            const popupWidth = 420;
+            const popupHeight = 560;
+            // Mevcut tarayıcı penceresinin sağ üstüne yerleştir (toolbar ikonu yakınına)
+            let left;
+            let top;
+            try {
+              const currentWindow = await chrome.windows.getCurrent();
+              if (currentWindow) {
+                left = Math.max(0, (currentWindow.left || 0) + (currentWindow.width || 1200) - popupWidth - 24);
+                top = (currentWindow.top || 0) + 72;
+              }
+            } catch {
+              // ignore positioning errors
+            }
+            await chrome.windows.create({
+              url: chrome.runtime.getURL("popup.html"),
+              type: "popup",
+              width: popupWidth,
+              height: popupHeight,
+              focused: true,
+              ...(left !== undefined ? { left: Math.round(left) } : {}),
+              ...(top !== undefined ? { top: Math.round(top) } : {}),
+            });
+          } else if (typeof window !== "undefined" && window.open) {
+            window.open(chrome.runtime.getURL("popup.html"), "_blank", "popup,width=420,height=560");
+          }
+        } catch (error) {
+          console.error("Failed to open popup window from sidebar:", error);
+        }
+      }
+    }
+
+    // Mevcut paneli kapat
+    setTimeout(() => {
+      try {
+        window.close();
+      } catch {
+        // ignore
+      }
+    }, 80);
+  });
+}
+
 // 更新搜索功能显示状态
 function updateSearchFeatureVisibility() {
   const searchWrapper = document.querySelector("#search-wrapper");
@@ -273,174 +406,104 @@ function updateSearchFeatureVisibility() {
     // 搜索功能关闭时，完全隐藏搜索相关元素
     searchWrapper.style.display = "none";
     hotArea.style.display = "none";
-    clearBestMatches();
+    // 清空最佳匹配
+    const bestMatchContainer = document.querySelector("#best-match");
+    if (bestMatchContainer) {
+      bestMatchContainer.innerHTML = "";
+    }
   } else {
     // 搜索功能开启时，恢复正常显示
-    searchWrapper.style.display = "";
+    searchWrapper.style.display = "block";
     hotArea.style.display = searchIsHide ? "block" : "none";
   }
 }
 
-function buildSearchIndex() {
-  const bookmarkElements = Array.from(document.querySelectorAll("#bookmarks .bookmark"));
-  searchFolders = Array.from(document.querySelectorAll("#bookmarks .folder"));
-  searchIndex = bookmarkElements.map((bookmarkElement, index) => {
-    const title = bookmarkElement.textContent || "";
-    const url = bookmarkElement.href || "";
-    const favicon = bookmarkElement.querySelector(".favicon")?.src || "";
+function showLoadingState() {
+  const bookmarksContainer = document.getElementById("bookmarks");
+  if (!bookmarksContainer) {
+    return;
+  }
+  if (bookmarksContainer.children.length > 0) {
+    return;
+  }
+  const loadingState = createElement("div", "loading-state", "");
+  loadingState.dataset.loading = "true";
+  loadingState.setAttribute("aria-label", navigator.language.startsWith("zh") ? "书签加载中" : "Loading bookmarks");
 
-    return {
-      id: index,
+  const loadingTitle = createElement("div", "loading-title", "");
+  const loadingGrid = createElement("div", "loading-grid", "");
+
+  for (let i = 0; i < 9; i++) {
+    loadingGrid.appendChild(createElement("div", "loading-card", ""));
+  }
+
+  loadingState.appendChild(loadingTitle);
+  loadingState.appendChild(loadingGrid);
+  bookmarksContainer.appendChild(loadingState);
+}
+
+// Bookmark / Fuse cache: search input'unun her keystroke'unda yeniden inşa etmemek için
+const FUSE_OPTIONS = {
+  keys: ["title", "url"],
+  ignoreLocation: false,
+  includeScore: true,
+  threshold: 0.5,
+  shouldSort: true,
+};
+let _bookmarkCache = null;
+let _fuseInstance = null;
+
+function invalidateBookmarkCache() {
+  _bookmarkCache = null;
+  _fuseInstance = null;
+}
+
+function getBookmarkCache() {
+  if (_bookmarkCache) return _bookmarkCache;
+  // Sadece #bookmarks ağacını cache'le; #best-match (search sonuçları) hariç
+  const root = document.getElementById("bookmarks");
+  if (!root) {
+    _bookmarkCache = { folders: [], items: [] };
+    return _bookmarkCache;
+  }
+  const folderEls = Array.from(root.getElementsByClassName(CLASS_NAMES.folder));
+  const items = [];
+  for (const el of root.getElementsByClassName(CLASS_NAMES.bookmark)) {
+    // Ata folder zincirini önceden hesapla (closest-first)
+    const ancestors = [];
+    let p = el.parentElement;
+    while (p && p !== root) {
+      if (p.classList?.contains(CLASS_NAMES.folder)) ancestors.push(p);
+      p = p.parentElement;
+    }
+    const title = el.textContent;
+    const url = el.href;
+    items.push({
+      el,
+      ancestors,
       title,
       titleLower: title.toLowerCase(),
       url,
       urlLower: url.toLowerCase(),
-      favicon,
-      element: bookmarkElement,
-      folder: bookmarkElement.closest(`.${CLASS_NAMES.folder}`),
-    };
-  });
-
-  const fuseData = searchIndex.map(({ id, title, url, favicon }) => ({ id, title, url, favicon }));
-  searchFuse = new Fuse(fuseData, FUSE_OPTIONS);
-}
-
-function getFuseResults(searchTerm) {
-  if (!searchFuse || !searchTerm) {
-    return [];
-  }
-  return searchFuse.search(searchTerm);
-}
-
-function getBestMatches(searchTerm) {
-  const results = getFuseResults(searchTerm);
-  if (results.length === 0) {
-    return null;
-  }
-
-  const uniqueMatches = [];
-  const cache = new Set();
-  for (const { item } of results) {
-    if (cache.has(item.url)) {
-      continue;
-    }
-    cache.add(item.url);
-    uniqueMatches.push({
-      title: item.title,
-      url: item.url,
-      favicon: item.favicon,
+      favicon: el.querySelector(".favicon")?.src,
     });
-    if (uniqueMatches.length === 3) {
-      break;
-    }
   }
-
-  return uniqueMatches.length > 0 ? uniqueMatches : null;
+  _bookmarkCache = { folders: folderEls, items };
+  return _bookmarkCache;
 }
 
-function applySearchFilter(searchTerm) {
-  if (!searchIndex.length) {
-    return;
-  }
-
-  const matchedIds = new Set();
-
-  if (!searchTerm) {
-    searchIndex.forEach(({ id }) => matchedIds.add(id));
-  } else {
-    searchIndex.forEach(({ id, titleLower, urlLower }) => {
-      if (titleLower.includes(searchTerm) || urlLower.includes(searchTerm)) {
-        matchedIds.add(id);
-      }
-    });
-
-    getFuseResults(searchTerm).forEach(({ item }) => matchedIds.add(item.id));
-  }
-
-  const folderVisibility = new Map(searchFolders.map((folder) => [folder, false]));
-  searchIndex.forEach((bookmark) => {
-    const shouldShow = matchedIds.has(bookmark.id);
-    const displayValue = shouldShow ? "flex" : "none";
-    if (bookmark.element.style.display !== displayValue) {
-      bookmark.element.style.display = displayValue;
-    }
-
-    if (shouldShow && bookmark.folder) {
-      let currentFolder = bookmark.folder;
-      while (currentFolder) {
-        folderVisibility.set(currentFolder, true);
-        currentFolder = currentFolder.parentElement?.closest(`.${CLASS_NAMES.folder}`);
-      }
-    }
-  });
-
-  folderVisibility.forEach((isVisible, folder) => {
-    const folderDisplay = isVisible ? "block" : "none";
-    if (folder.style.display !== folderDisplay) {
-      folder.style.display = folderDisplay;
-    }
-  });
-
-  if (!searchTerm) {
-    restorePersistedHeader();
-  } else {
-    updateHeader(getBestMatches(searchTerm));
-  }
-}
-
-/**
- * 切换 searchBar 显示状态
- */
-function switchSearchBarShowStatus() {
-  // 如果搜索功能关闭，则不允许切换
-  if (!isSearchEnabled()) {
-    return;
-  }
-
-  searchIsHide = !searchIsHide;
-  localStorage.setItem("SHOW_SEARCH_BAR", searchIsHide ? "false" : "true");
-  const extraClass = searchIsHide ? "" : "show";
-  const container = document.querySelector("#search-wrapper");
-  // 有一个8px的间距，所以减去8
-  const containerHeight = container.clientHeight - 8;
-  const bookmarksContainer = document.querySelector("#bookmarks");
-
-  if (container) {
-    container.classList.remove("show");
-    if (extraClass) {
-      container.classList.add(extraClass);
-      bookmarksContainer.style.transform = `translateY(0)`;
-      scheduleSearchInputFocus();
-      hotArea.style.display = "none";
-    } else {
-      bookmarksContainer.style.transform = `translateY(-${containerHeight}px)`;
-      hotArea.style.display = "block";
-    }
-  }
-
-  // 智能更新窗口高度
-  setTimeout(() => {
-    updatePopupHeight();
-  }, 300); // 等待搜索框动画完成
+function getFuseInstance() {
+  if (_fuseInstance) return _fuseInstance;
+  const { items } = getBookmarkCache();
+  _fuseInstance = new Fuse(items, FUSE_OPTIONS);
+  return _fuseInstance;
 }
 
 /**
  * 智能更新popup高度
  */
 function updatePopupHeight() {
-  const newHeight = calculateOptimalHeight();
-  const currentHeight = parseInt(document.body.style.height) || 400;
-
-  // 如果高度有显著变化，使用平滑过渡
-  if (Math.abs(newHeight - currentHeight) > 10) {
-    document.body.style.transition = "height 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
-    document.body.style.height = `${newHeight}px`;
-
-    // 动画结束后移除过渡效果
-    setTimeout(() => {
-      document.body.style.transition = "";
-    }, 250);
-  }
+  applyFixedPopupSize();
 }
 
 /**
@@ -487,15 +550,17 @@ function showBestMatchTips() {
  * @param init {boolean} 是否是初始化
  */
 function updateHeader(headerFuzeMatch, init = false) {
-  if (!headerFuzeMatch || headerFuzeMatch.length === 0) {
-    clearBestMatches();
+  if (!headerFuzeMatch) {
     return;
   }
   // 兼容旧版本，上一个版本 headerFuzeMatch 为单个对象
   if (!Array.isArray(headerFuzeMatch)) {
-    headerFuzeMatch = [headerFuzeMatch];
+    headerFuzeMatch = Array.from(headerFuzeMatch);
   }
-  clearBestMatches();
+  const matchedBookmark = document.querySelector("#best-match .folder");
+  if (matchedBookmark) {
+    matchedBookmark.parentElement.removeChild(matchedBookmark);
+  }
   const bestMatchFolder = createElement("div", CLASS_NAMES.folder);
   const childContainer = createElement("div", CLASS_NAMES.childContainer);
   const title = createElement("h2", "", init ? LastBestMatch : BestMatch);
@@ -507,9 +572,7 @@ function updateHeader(headerFuzeMatch, init = false) {
   bestMatchFolder.appendChild(childContainer);
   bestMatches = headerFuzeMatch;
 
-  if (!init) {
-    localStorage.setItem("persistedHeader", JSON.stringify(headerFuzeMatch));
-  }
+  localStorage.setItem("persistedHeader", JSON.stringify(headerFuzeMatch));
   document.querySelector("#best-match").appendChild(bestMatchFolder);
   updateActiveBestMatch(0);
 }
@@ -531,38 +594,56 @@ function checkOverflow(el) {
   return isOverflowing;
 }
 
-searchInput.addEventListener(
-  "input",
-  debounce(function () {
-    if (!isSearchEnabled()) {
-      return;
-    }
-    const searchTerm = searchInput.value.toLowerCase();
-    applySearchFilter(searchTerm);
-  }, 30)
-);
+// Search input: cached Fuse + tek geçişli filtreleme (her keystroke'ta tek Fuse search)
+if (isSearchEnabled()) {
+  searchInput.addEventListener(
+    "input",
+    debounce(function () {
+      const rawTerm = searchInput.value;
+      const searchTerm = rawTerm.toLowerCase().trim();
+      const { folders, items } = getBookmarkCache();
 
-hideArrow.addEventListener("click", function () {
-  if (!isSearchEnabled()) {
-    return;
-  }
-  switchSearchBarShowStatus();
-  if (!searchIsHide) {
-    scheduleSearchInputFocus();
-  }
-});
+      // Boş arama: her şeyi göster, header'ı temizle
+      if (!searchTerm) {
+        for (const it of items) it.el.style.display = "flex";
+        for (const folder of folders) folder.style.display = "block";
+        const bestMatchContainer = document.querySelector("#best-match");
+        if (bestMatchContainer) bestMatchContainer.innerHTML = "";
+        bestMatches = [];
+        return;
+      }
 
-hideArrowIcon.addEventListener("mouseover", function () {
-  if (!isSearchEnabled()) {
-    return;
-  }
-  const tips = searchIsHide ? ShowSearchWrapper : HideSearchWrapper;
-  Notification.show(tips);
-});
+      // Tek Fuse search; tüm sonuçları al, dedupe et
+      const fuse = getFuseInstance();
+      const results = fuse.search(searchTerm);
+      const matchedUrls = new Set();
+      const orderedMatches = [];
+      for (const r of results) {
+        if (!matchedUrls.has(r.item.url)) {
+          matchedUrls.add(r.item.url);
+          orderedMatches.push(r.item);
+        }
+      }
 
-hideArrowIcon.addEventListener("mouseleave", function () {
-  Notification.hide();
-});
+      // Görünür bookmark'ı içeren tüm ata folder'ları işaretle (nested folders için)
+      const visibleFolders = new Set();
+      for (const it of items) {
+        const visible =
+          it.titleLower.includes(searchTerm) || it.urlLower.includes(searchTerm) || matchedUrls.has(it.url);
+        it.el.style.display = visible ? "flex" : "none";
+        if (visible) {
+          for (const f of it.ancestors) visibleFolders.add(f);
+        }
+      }
+      for (const folder of folders) {
+        folder.style.display = visibleFolders.has(folder) ? "block" : "none";
+      }
+
+      // Top 3 best-match header'da
+      updateHeader(orderedMatches.length ? orderedMatches.slice(0, 3) : null);
+    }, 80)
+  );
+}
 
 // fix under mask click
 document.addEventListener("click", function (e) {
@@ -572,13 +653,8 @@ document.addEventListener("click", function (e) {
       e.target.id === "hot-area"
   );
   if (underMaskEle) {
-    const clickEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      clientX: e.clientX,
-      clientY: e.clientY,
-      ctrlKey: e.ctrlKey,
-      metaKey: e.metaKey,
+    const clickEvent = new CustomEvent("click", {
+      detail: {},
     });
     underMaskEle.dispatchEvent(clickEvent);
   }
@@ -590,7 +666,17 @@ window.addEventListener("keydown", function (event) {
     // 只在搜索功能开启时才处理清空搜索
     if (isSearchEnabled()) {
       searchInput.value = "";
-      applySearchFilter("");
+
+      let bookmarks = document.getElementsByClassName(CLASS_NAMES.bookmark);
+      let folders = document.getElementsByClassName(CLASS_NAMES.folder);
+
+      for (let bookmark of bookmarks) {
+        bookmark.style.display = "flex";
+      }
+
+      for (let folder of folders) {
+        folder.style.display = "block";
+      }
     }
   }
 
@@ -625,252 +711,97 @@ window.addEventListener("keydown", function (event) {
 
   if (event.ctrlKey && event.key === "s") {
     event.preventDefault();
-    // 只在搜索功能开启时才允许切换
+    // Search bar her zaman görünür — Ctrl+S sadece odakla
     if (isSearchEnabled()) {
-      switchSearchBarShowStatus();
+      searchInput?.focus();
     }
   }
 });
 
+function applySearchLayout(container, bookmarksContainer) {
+  if (!container || !bookmarksContainer || !isSearchEnabled()) {
+    return;
+  }
+  if (searchIsHide) {
+    // -8 是因为有 8px 的 margin
+    const searchBarContainerHeight = container.clientHeight - 8;
+    bookmarksContainer.style.transform = `translateY(-${searchBarContainerHeight}px)`;
+    hotArea.style.display = "block";
+  } else {
+    container.classList.add("show");
+    bookmarksContainer.style.transform = `translateY(-8px)`;
+    searchInput.focus();
+    hotArea.style.display = "none";
+  }
+}
+
+function finishPopupLayout(container, bookmarksContainer) {
+  void container;
+  void bookmarksContainer;
+  applyFixedPopupSize();
+}
+
+function renderBookmarkTree(bookmarkTreeNodes) {
+  if (!bookmarkTreeNodes || !bookmarkTreeNodes.length) {
+    return;
+  }
+  folderCount = countFolders(bookmarkTreeNodes[0].children || []);
+  const container = document.querySelector("#search-wrapper");
+  const bookmarksContainer = document.querySelector("#bookmarks");
+
+  createBookmarks(bookmarkTreeNodes);
+  updateSearchFeatureVisibility();
+  applySearchLayout(container, bookmarksContainer);
+  finishPopupLayout(container, bookmarksContainer);
+}
+
+async function fetchBookmarkTree() {
+  if (typeof browser !== "undefined") {
+    return await browser.bookmarks.getTree();
+  }
+  return await chrome.bookmarks.getTree();
+}
+
+async function initializePopup() {
+  showLoadingState();
+
+  try {
+    const bookmarkTreeNodes = await fetchBookmarkTree();
+    renderBookmarkTree(bookmarkTreeNodes);
+  } catch (error) {
+    console.error("Failed to load bookmark tree:", error);
+  } finally {
+    document.body.classList.remove("popup-loading");
+    requestAnimationFrame(() => {
+      document.body.classList.add("popup-interactive");
+    });
+  }
+}
+
+// 在DOM ready时立即设置高度并初始化
 document.addEventListener("DOMContentLoaded", function () {
   setBodyHeightFromStorage();
-  scheduleSearchInputFocus();
   initializePopup();
 });
 
-window.addEventListener("pageshow", function () {
-  if (isPopupInitialized) {
-    initializePopup({ force: true });
-  }
-});
-
-async function initializePopup({ force = false } = {}) {
-  if (isPopupInitializing || (isPopupInitialized && !force)) {
-    return;
-  }
-
-  isPopupInitializing = true;
-  resetPopupState();
-
-  try {
-    const bookmarkTreeNodes = await getBookmarkTree();
-    folderCount = countFolders(bookmarkTreeNodes?.[0]?.children || []);
-    const container = document.querySelector("#search-wrapper");
-    const bookmarksContainer = document.querySelector("#bookmarks");
-
-    createBookmarks(bookmarkTreeNodes);
-    buildSearchIndex();
-
-    updateSearchFeatureVisibility();
-    applySearchWrapperState(container, bookmarksContainer);
-
-    if (isSearchEnabled()) {
-      restorePersistedHeader();
-    }
-
-    const actualHeight = calculateOptimalHeight();
-    updateBodyHeight(actualHeight);
-
-    setTimeout(() => {
-      if (container) {
-        container.style.transition = "all 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
-      }
-      if (bookmarksContainer) {
-        bookmarksContainer.style.transition = "all 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
-      }
-    }, 100);
-
-    isPopupInitialized = true;
-  } catch (error) {
-    console.error("Failed to initialize popup:", error);
-    showInitializationError();
-  } finally {
-    isPopupInitializing = false;
-  }
-}
-
-function resetPopupState() {
-  searchIsHide = getSearchHiddenState();
-  folderCount = 0;
-  activeBestMatchIndex = 0;
-  searchIndex = [];
-  searchFuse = null;
-  searchFolders = [];
-
-  if (hideTimeout) {
-    clearTimeout(hideTimeout);
-    hideTimeout = null;
-  }
-
-  const searchWrapper = document.querySelector("#search-wrapper");
-  const bookmarksContainer = document.querySelector("#bookmarks");
-  const hotArea = document.querySelector("#hot-area");
-
-  clearBestMatches();
-
-  if (bookmarksContainer) {
-    bookmarksContainer.innerHTML = "";
-    bookmarksContainer.style.transform = "";
-    bookmarksContainer.style.transition = "";
-  }
-
-  if (searchWrapper) {
-    searchWrapper.classList.remove("show");
-    searchWrapper.style.display = "";
-    searchWrapper.style.transition = "";
-    searchWrapper.style.marginTop = "-30px";
-  }
-
-  if (searchInput) {
-    searchInput.value = "";
-  }
-
-  if (hotArea) {
-    hotArea.style.display = "none";
-  }
-}
-
-function applySearchWrapperState(container, bookmarksContainer) {
-  if (!container || !bookmarksContainer) {
-    return;
-  }
-
-  if (!isSearchEnabled()) {
-    container.classList.remove("show");
-    bookmarksContainer.style.transform = "";
-    hotArea.style.display = "none";
-    return;
-  }
-
-  if (searchIsHide) {
-    const searchBarContainerHeight = Math.max(container.clientHeight - 8, 0);
-    container.classList.remove("show");
-    bookmarksContainer.style.transform = `translateY(-${searchBarContainerHeight}px)`;
-    hotArea.style.display = "block";
-    return;
-  }
-
-  container.classList.add("show");
-  bookmarksContainer.style.transform = "translateY(-8px)";
-  hotArea.style.display = "none";
-  scheduleSearchInputFocus();
-}
-
-function updateBodyHeight(actualHeight) {
-  setTimeout(() => {
-    const currentHeight = parseInt(getComputedStyle(document.body).height, 10) || 400;
-
-    if (Math.abs(actualHeight - currentHeight) > 20) {
-      document.body.style.transition = "height 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
-      document.body.style.height = `${actualHeight}px`;
-
-      setTimeout(() => {
-        document.body.style.transition = "";
-      }, 250);
-    } else {
-      document.body.style.height = `${actualHeight}px`;
-    }
-  }, 200);
-}
-
 function setBodyHeightFromStorage() {
-  let savedHeight = localStorage.getItem("savedHeight");
-  let savedSearchEnabled = localStorage.getItem("MAPLE_SEARCH_ENABLED");
-  const parsedSavedHeight = Number.parseInt(savedHeight, 10);
-
-  if (Number.isFinite(parsedSavedHeight) && parsedSavedHeight > 30) {
-    const height = clamp(parsedSavedHeight, 200, 618);
-    document.body.style.height = `${height}px`;
-  } else {
-    let initialHeight = 400;
-    if (savedSearchEnabled === "true") {
-      initialHeight = 460;
-    } else {
-      initialHeight = 380;
-    }
-    document.body.style.height = `${initialHeight}px`;
-  }
-}
-
-function calculateOptimalHeight() {
-  const bookmarksContainer = document.getElementById("bookmarks");
-  const searchWrapper = document.querySelector("#search-wrapper");
-  const settingsBtn = document.querySelector(".settings-btn");
-
-  let totalHeight = 20; // 基础padding
-
-  // 计算书签容器高度
-  if (bookmarksContainer) {
-    totalHeight += bookmarksContainer.scrollHeight;
-  }
-
-  // 计算搜索框高度（只有当搜索功能开启且显示时）
-  if (isSearchEnabled() && !searchIsHide && searchWrapper) {
-    totalHeight += searchWrapper.scrollHeight;
-  }
-
-  // 计算最佳匹配区域高度
-  const bestMatchContainer = document.querySelector("#best-match");
-  if (bestMatchContainer && bestMatchContainer.children.length > 0 && searchIsHide) {
-    totalHeight += bestMatchContainer.scrollHeight;
-  }
-
-  // 考虑设置按钮的影响
-  if (settingsBtn) {
-    totalHeight += 10; // 设置按钮的额外空间
-  }
-
-  // 限制最大高度并保证最小高度
-  const optimalHeight = Math.min(Math.max(totalHeight, 200), 618);
-
-  // 保存计算结果到本地存储
-  localStorage.setItem("savedHeight", optimalHeight.toString());
-  localStorage.setItem("SHOW_SEARCH_BAR", searchIsHide ? "false" : "true");
-
-  return optimalHeight;
+  applyFixedPopupSize();
 }
 
 function createBookmarks(bookmarkTreeNodes) {
   const bookmarksContainer = document.getElementById("bookmarks");
+  bookmarksContainer.innerHTML = "";
 
   if (folderCount === 0) {
     showEmptyBookmarkMessage();
   } else {
-    showBookmarks(bookmarkTreeNodes, bookmarksContainer);
+    // DocumentFragment ile DOM'a tek seferde ekle (reflow azaltır)
+    const fragment = document.createDocumentFragment();
+    showBookmarks(bookmarkTreeNodes, fragment);
+    bookmarksContainer.appendChild(fragment);
   }
-  bindSwitchModeToFirstFolder();
-}
-
-function bindSwitchModeToFirstFolder() {
-  // 只在搜索功能开启时才绑定hover效果
-  if (!isSearchEnabled() || hasBoundHotAreaHover) {
-    return;
-  }
-
-  const hotArea = document.querySelector("#hot-area");
-  const searchWrapper = document.querySelector("#search-wrapper");
-  const arrow = document.querySelector(".arrow");
-  hotArea.addEventListener("mouseover", () => {
-    arrow.style.opacity = 1;
-    searchWrapper.style.marginTop = 0;
-  });
-
-  hotArea.addEventListener("mouseleave", () => {
-    arrow.style.opacity = 0;
-    searchWrapper.style.marginTop = "-30px";
-  });
-  hasBoundHotAreaHover = true;
-}
-
-function showInitializationError() {
-  const bookmarksContainer = document.getElementById("bookmarks");
-  if (!bookmarksContainer) {
-    return;
-  }
-
-  bookmarksContainer.innerHTML = "";
-  const message = navigator.language.startsWith("zh") ? "书签加载失败，请重新打开扩展" : "Failed to load bookmarks. Try reopening the extension.";
-  bookmarksContainer.appendChild(createElement("p", "message", message));
+  // Bookmark DOM'u değişti; arama cache'ini geçersiz kıl
+  invalidateBookmarkCache();
 }
 
 function showEmptyBookmarkMessage() {

--- a/bookmark/settings.html
+++ b/bookmark/settings.html
@@ -221,6 +221,19 @@
 
       <div class="setting-item">
         <div class="setting-label">
+          <div class="setting-title" id="displayModeTitle">Display Mode</div>
+          <div class="setting-description" id="displayModeDesc">
+            Choose how Maple opens. Popup and sidebar modes are mutually exclusive - only one will be active at a time.
+          </div>
+        </div>
+        <label class="switch" title="Off: popup · On: sidebar">
+          <input type="checkbox" id="sidebarMode" />
+          <span class="slider"></span>
+        </label>
+      </div>
+
+      <div class="setting-item">
+        <div class="setting-label">
           <div class="setting-title" id="searchFeatureTitle">Search Functionality</div>
           <div class="setting-description" id="searchFeatureDesc">
             Enable search box to quickly find bookmarks. When disabled, all search features will be hidden.
@@ -272,7 +285,7 @@
       </div>
 
       <div class="footer">
-        <div class="version" id="versionText">Maple Bookmarks v1.17</div>
+        <div class="version" id="versionText">Maple Bookmarks v2.0</div>
       </div>
     </div>
 

--- a/bookmark/settings.js
+++ b/bookmark/settings.js
@@ -6,7 +6,12 @@ const SETTINGS_KEYS = {
   KEEP_PANEL_OPEN: "MAPLE_KEEP_PANEL_OPEN",
 };
 
+const DISPLAY_MODE_KEY = "MAPLE_DISPLAY_MODE";
+const MODE_POPUP = "popup";
+const MODE_SIDEBAR = "sidebar";
+
 // 获取DOM元素
+const sidebarModeCheckbox = document.getElementById("sidebarMode");
 const searchEnabledCheckbox = document.getElementById("searchEnabled");
 const tipsEnabledCheckbox = document.getElementById("tipsEnabled");
 const openInNewTabCheckbox = document.getElementById("openInNewTab");
@@ -21,6 +26,10 @@ const isZh = browserLanguage === "zh";
 const texts = {
   title: isZh ? "设置" : "Settings",
   backBtn: isZh ? "← 返回" : "← Back",
+  displayModeTitle: isZh ? "显示模式（侧边栏）" : "Display Mode (Sidebar)",
+  displayModeDesc: isZh
+    ? "开启后点击图标打开侧边栏，关闭后打开弹窗。两者不会同时显示。"
+    : "When on, clicking the icon opens the sidebar; when off, it opens the popup. They are never shown at the same time.",
   searchFeatureTitle: isZh ? "启用搜索功能" : "Search Functionality",
   searchFeatureDesc: isZh
     ? "开启后可以使用搜索框搜索书签，关闭后将隐藏搜索相关功能"
@@ -37,13 +46,15 @@ const texts = {
   keepPanelOpenDesc: isZh
     ? "开启后点击书签会在后台标签页打开，并尽量保持面板不自动关闭"
     : "Keep the panel open after clicking by opening bookmarks in background tabs.",
-  versionText: "Maple Bookmarks v1.17",
+  versionText: "Maple Bookmarks v2.0",
 };
 
 // 应用国际化文本
 function applyI18n() {
   document.getElementById("title").textContent = texts.title;
   document.getElementById("backBtn").textContent = texts.backBtn;
+  document.getElementById("displayModeTitle").textContent = texts.displayModeTitle;
+  document.getElementById("displayModeDesc").textContent = texts.displayModeDesc;
   document.getElementById("searchFeatureTitle").textContent = texts.searchFeatureTitle;
   document.getElementById("searchFeatureDesc").textContent = texts.searchFeatureDesc;
   document.getElementById("tipsFeatureTitle").textContent = texts.tipsFeatureTitle;
@@ -79,6 +90,13 @@ function loadSettings() {
   // 默认点击后自动关闭
   const keepPanelOpen = localStorage.getItem(SETTINGS_KEYS.KEEP_PANEL_OPEN) === "true";
   keepPanelOpenCheckbox.checked = keepPanelOpen;
+
+  // 显示模式：默认 popup
+  if (typeof chrome !== "undefined" && chrome.storage?.local) {
+    chrome.storage.local.get(DISPLAY_MODE_KEY, (result) => {
+      sidebarModeCheckbox.checked = result?.[DISPLAY_MODE_KEY] === MODE_SIDEBAR;
+    });
+  }
 }
 
 // 保存设置
@@ -89,46 +107,22 @@ function saveSettings() {
   localStorage.setItem(SETTINGS_KEYS.KEEP_PANEL_OPEN, keepPanelOpenCheckbox.checked.toString());
 }
 
-async function closeCurrentExtensionTab() {
-  if (typeof browser !== "undefined" && browser.tabs?.getCurrent && browser.tabs?.remove) {
-    const currentTab = await browser.tabs.getCurrent();
-    if (currentTab?.id) {
-      await browser.tabs.remove(currentTab.id);
-      return true;
-    }
-  }
-
-  if (typeof chrome !== "undefined" && chrome.tabs?.getCurrent && chrome.tabs?.remove) {
-    return new Promise((resolve) => {
-      chrome.tabs.getCurrent((currentTab) => {
-        if (currentTab?.id) {
-          chrome.tabs.remove(currentTab.id, () => resolve(true));
-          return;
-        }
-        resolve(false);
-      });
+// 通过 service worker 更新显示模式，确保 popup 与 sidebar 互斥
+function saveDisplayMode() {
+  const nextMode = sidebarModeCheckbox.checked ? MODE_SIDEBAR : MODE_POPUP;
+  try {
+    chrome.runtime.sendMessage({
+      type: "MAPLE_SET_MODE",
+      mode: nextMode,
+      openImmediately: false,
     });
+  } catch (error) {
+    console.error("Failed to update display mode:", error);
   }
-
-  return false;
 }
 
 // 返回到主页面
-async function goBack() {
-  if (window.history.length > 1) {
-    window.history.back();
-    return;
-  }
-
-  try {
-    const closedTab = await closeCurrentExtensionTab();
-    if (closedTab) {
-      return;
-    }
-  } catch (error) {
-    console.error("Failed to close settings tab:", error);
-  }
-
+function goBack() {
   window.close();
 }
 
@@ -136,6 +130,7 @@ async function goBack() {
 document.addEventListener("DOMContentLoaded", loadSettings);
 
 // 事件监听器
+sidebarModeCheckbox.addEventListener("change", saveDisplayMode);
 searchEnabledCheckbox.addEventListener("change", saveSettings);
 tipsEnabledCheckbox.addEventListener("change", saveSettings);
 openInNewTabCheckbox.addEventListener("change", saveSettings);

--- a/bookmark/sidebar.html
+++ b/bookmark/sidebar.html
@@ -1,51 +1,35 @@
 <!doctype html>
-<html style="width: 408px; min-width: 408px; max-width: 408px; height: 520px; min-height: 520px; max-height: 520px;">
+<html>
   <head>
     <meta charset="UTF-8" />
     <title>Maple Bookmarks</title>
-    <script src="height-init.js"></script>
     <link rel="stylesheet" href="theme.css" />
     <style>
-      html {
-        width: 408px;
-        min-width: 408px;
-        max-width: 408px;
-        height: 520px;
-        min-height: 520px;
-        max-height: 520px;
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
       }
 
       body {
-        margin: 0;
-        padding: 44px 0 12px 14px;
-        width: 408px;
-        min-width: 408px;
-        max-width: 408px;
-        height: 520px;
-        min-height: 520px;
-        max-height: 520px;
+        padding: 44px 14px 12px 14px;
         box-sizing: border-box;
         overflow-x: hidden;
         overflow-y: auto;
       }
 
-      #header {
-        width: 384px;
-      }
-
+      #header,
       .search-action {
-        width: 384px;
+        width: 100%;
       }
 
       #bookmarks {
-        min-height: 360px;
+        min-height: 60vh;
       }
     </style>
   </head>
-  <body
-    class="popup-loading"
-    style="width: 408px; min-width: 408px; max-width: 408px; height: 520px; min-height: 520px; max-height: 520px;"
-  >
+  <body class="popup-loading">
     <div class="settings-wrapper">
       <button class="mode-btn" id="modeBtn" title="">🪟</button>
       <button class="settings-btn" id="settingsBtn" title="">⚙️</button>

--- a/bookmark/theme.css
+++ b/bookmark/theme.css
@@ -1,0 +1,558 @@
+/* Maple Bookmarks — shared visual theme.
+   Layout-specific rules (fixed vs responsive) live in each HTML's inline <style>. */
+
+:root {
+  --maple-bg: #faf7f3;
+  --maple-card: #ffffff;
+  --maple-card-hover: #fdf2ec;
+  --maple-card-active: #f7e2d6;
+  --maple-text: #2c2825;
+  --maple-text-secondary: #847b71;
+  --maple-text-muted: #a89d92;
+  --maple-accent: #e85d4d;
+  --maple-accent-soft: rgba(232, 93, 77, 0.08);
+  --maple-border: rgba(0, 0, 0, 0.04);
+  --maple-shadow-sm: 0 1px 2px rgba(60, 40, 30, 0.04), 0 1px 3px rgba(60, 40, 30, 0.05);
+  --maple-shadow-md: 0 4px 12px rgba(232, 93, 77, 0.1), 0 2px 4px rgba(60, 40, 30, 0.08);
+  --maple-shadow-lg: 0 8px 24px rgba(60, 40, 30, 0.12);
+  --maple-radius: 10px;
+  --maple-radius-sm: 6px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --maple-bg: #1c1a17;
+    --maple-card: #2a2622;
+    --maple-card-hover: #353029;
+    --maple-card-active: #4a3d33;
+    --maple-text: #f1ebe4;
+    --maple-text-secondary: #a89d92;
+    --maple-text-muted: #847b71;
+    --maple-accent: #f08070;
+    --maple-accent-soft: rgba(240, 128, 112, 0.12);
+    --maple-border: rgba(255, 255, 255, 0.06);
+    --maple-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+    --maple-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);
+    --maple-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+}
+
+body {
+  background: var(--maple-bg);
+  color: var(--maple-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Helvetica Neue", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::-webkit-scrollbar {
+  display: none;
+}
+
+#hot-area {
+  position: absolute;
+  top: 0;
+  left: 20%;
+  width: 70%;
+  height: 40px;
+  z-index: 100;
+  cursor: pointer;
+}
+
+/* Modern floating tooltip — bottom center, fades in with subtle slide */
+#notification-container {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translate(-50%, 16px);
+  opacity: 0;
+  z-index: 250;
+  pointer-events: none;
+  max-width: calc(100% - 28px);
+  padding: 9px 16px;
+  background: rgba(28, 24, 20, 0.94);
+  color: #f5f1ec;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: 0.1px;
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28), 0 2px 6px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(10px) saturate(1.4);
+  -webkit-backdrop-filter: blur(10px) saturate(1.4);
+  transition: opacity 0.18s ease, transform 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#notification-container.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (prefers-color-scheme: dark) {
+  #notification-container {
+    background: rgba(245, 240, 232, 0.94);
+    color: #1c1a17;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.folder {
+  width: 100%;
+}
+
+h2 {
+  padding-left: 4px;
+  font-weight: 600;
+  color: var(--maple-text-secondary);
+  line-height: 1;
+  letter-spacing: 0.4px;
+  margin-block-end: 12px;
+  margin-block-start: 18px;
+  user-select: none;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+
+/* İlk folder başlığının üstünde extra boşluk: settings/mode iconları için yer */
+#bookmarks > .folder:first-child > h2:first-child,
+#bookmarks > .folder:first-child > .folderTitle:first-child {
+  margin-top: 4px;
+}
+
+.folderTitle.collapsible-folder {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-right: 24px;
+  cursor: pointer;
+  border-radius: var(--maple-radius-sm);
+  padding: 6px 24px 6px 4px;
+  margin-block-end: 8px;
+  margin-block-start: 12px;
+  transition: background 0.15s ease;
+}
+
+.folderTitle.collapsible-folder:hover {
+  background: var(--maple-accent-soft);
+  color: var(--maple-accent);
+}
+
+.folderTitle .folder-arrow {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.folderTitle .folder-arrow::before {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 6px;
+  border: solid var(--maple-text-muted);
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(-45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.folderTitle.collapsible-folder:hover .folder-arrow::before {
+  border-color: var(--maple-accent);
+}
+
+.folderTitle.collapsible-folder.expanded .folder-arrow::before {
+  transform: rotate(45deg);
+}
+
+.folderTitle .folder-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+p.message {
+  color: var(--maple-text-secondary);
+  text-align: center;
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 1.6;
+  padding: 40px 20px;
+}
+
+.loading-state {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+body.popup-loading #search-wrapper,
+body.popup-loading #hot-area,
+body.popup-loading #notification-container,
+body.popup-loading .settings-wrapper {
+  visibility: hidden;
+}
+
+.loading-title {
+  width: 80px;
+  height: 11px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--maple-card) 25%, var(--maple-card-hover) 37%, var(--maple-card) 63%);
+  background-size: 400% 100%;
+  margin: 14px 0 12px 4px;
+  animation: mapleSkeleton 1.4s ease-in-out infinite;
+}
+
+.loading-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.loading-card {
+  width: 120px;
+  height: 44px;
+  box-sizing: border-box;
+  border-radius: var(--maple-radius);
+  background: linear-gradient(90deg, var(--maple-card) 25%, var(--maple-card-hover) 37%, var(--maple-card) 63%);
+  background-size: 400% 100%;
+  margin-bottom: 10px;
+  margin-right: 10px;
+  animation: mapleSkeleton 1.4s ease-in-out infinite;
+  box-shadow: var(--maple-shadow-sm);
+}
+
+@keyframes mapleSkeleton {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+.childContainer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+#search-wrapper {
+  margin-bottom: 14px;
+  position: relative;
+  margin-top: 0;
+  transform: translateY(0);
+}
+
+#search-wrapper.show {
+  transform: translateY(0);
+  margin-top: 0;
+  height: auto;
+}
+
+/* Search artık her zaman görünür — toggle arrow ve hot-area gerekmiyor */
+.search-action,
+#hot-area {
+  display: none !important;
+}
+
+#best-match .bookmark.active {
+  background: var(--maple-card-active);
+  box-shadow: var(--maple-shadow-md);
+}
+
+.childContainer > .bookmark {
+  width: 120px;
+  height: 44px;
+  box-sizing: border-box;
+  border-radius: var(--maple-radius);
+  background-color: var(--maple-card);
+  padding: 6px 12px;
+  margin-bottom: 10px;
+  margin-right: 10px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  box-shadow: var(--maple-shadow-sm);
+  border: 1px solid var(--maple-border);
+  transition: all 0.18s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.childContainer > .bookmark:hover {
+  background-color: var(--maple-card-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--maple-shadow-md);
+  border-color: transparent;
+}
+
+.bookmark p {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--maple-text);
+  margin-left: 9px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.favicon {
+  height: 18px;
+  width: 18px;
+  margin-left: 2px;
+  flex-shrink: 0;
+}
+
+#header {
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+}
+
+#searchInput {
+  width: 100%;
+  padding: 11px 16px;
+  font-size: 15px;
+  height: 20px;
+  line-height: 20px;
+  color: var(--maple-text);
+  outline: none;
+  caret-color: var(--maple-accent);
+  background: transparent;
+  text-align: center;
+  border: none;
+  font-weight: 500;
+}
+
+#searchInput::placeholder {
+  color: var(--maple-text-muted);
+  font-weight: 400;
+}
+
+#search-wrapper.show #searchInput {
+  border-bottom: 1px solid var(--maple-border);
+}
+
+.settings-wrapper {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  z-index: 200;
+}
+
+.settings-btn,
+.mode-btn {
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: var(--maple-radius-sm);
+  background-color: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--maple-text-secondary);
+  transition: all 0.18s ease;
+  opacity: 0.7;
+  pointer-events: auto;
+  padding: 0;
+}
+
+.settings-btn {
+  font-size: 16px;
+}
+
+.settings-btn:hover,
+.mode-btn:hover,
+.settings-btn:focus,
+.settings-btn:focus-visible,
+.mode-btn:focus,
+.mode-btn:focus-visible {
+  opacity: 1;
+  background-color: var(--maple-accent-soft);
+  color: var(--maple-accent);
+  transform: scale(1.08);
+}
+
+/* ======= Settings Overlay (popup + sidebar) ======= */
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--maple-bg);
+  z-index: 300;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.26s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  overflow: hidden;
+}
+
+.settings-overlay[hidden] {
+  display: none;
+}
+
+.settings-overlay.open {
+  transform: translateX(0);
+}
+
+.settings-overlay-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--maple-border);
+  background: var(--maple-bg);
+  flex-shrink: 0;
+}
+
+.settings-overlay-back {
+  background: var(--maple-card);
+  border: 1px solid var(--maple-border);
+  border-radius: var(--maple-radius-sm);
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--maple-text-secondary);
+  transition: all 0.18s ease;
+  font-size: 16px;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.settings-overlay-back:hover {
+  background: var(--maple-card-hover);
+  color: var(--maple-accent);
+  border-color: var(--maple-accent-soft);
+}
+
+.settings-overlay-title {
+  flex: 1;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--maple-text);
+  margin: 0;
+  margin-right: 32px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.settings-overlay-body {
+  flex: 1;
+  padding: 4px 16px 16px;
+  overflow-y: auto;
+}
+
+.settings-overlay-body::-webkit-scrollbar {
+  display: none;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--maple-border);
+}
+
+.setting-row:last-child {
+  border-bottom: none;
+}
+
+.setting-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--maple-text);
+  margin-bottom: 4px;
+  letter-spacing: 0;
+}
+
+.setting-desc {
+  font-size: 11.5px;
+  color: var(--maple-text-secondary);
+  line-height: 1.45;
+}
+
+.maple-switch {
+  position: relative;
+  display: inline-block;
+  width: 38px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.maple-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.maple-switch-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.2);
+  transition: 0.22s;
+  border-radius: 22px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .maple-switch-slider {
+    background: rgba(255, 255, 255, 0.16);
+  }
+}
+
+.maple-switch-slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  transition: 0.22s;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.maple-switch input:checked + .maple-switch-slider {
+  background: var(--maple-accent);
+}
+
+.maple-switch input:checked + .maple-switch-slider:before {
+  transform: translateX(16px);
+}
+
+.settings-overlay-footer {
+  padding: 12px 16px 16px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--maple-text-muted);
+  flex-shrink: 0;
+}

--- a/bookmark/utils/i18n.js
+++ b/bookmark/utils/i18n.js
@@ -1,7 +1,10 @@
 const browserLanguage = navigator.language.startsWith("zh") ? "zh" : "en";
 const isZh = browserLanguage === "zh";
 
-document.getElementById("searchInput").placeholder = isZh ? "搜索书签..." : "Search bookmarks...";
+const searchInputEl = document.getElementById("searchInput");
+if (searchInputEl) {
+  searchInputEl.placeholder = isZh ? "搜索书签..." : "Search bookmarks...";
+}
 
 const isMac = navigator.platform.indexOf("Mac") !== -1;
 
@@ -17,15 +20,4 @@ const BestMatch = isZh ? "最佳匹配" : "Best Matches";
 
 const EmptyBookmarkMessage = isZh ? "🍁 没有找到书签" : "🍁 No bookmarks found in your browser";
 
-const ShowSearchWrapper = isZh ? "显示搜索框，试试 Ctrl + S" : "Show search box (Try Ctrl + S)";
-const HideSearchWrapper = isZh ? "隐藏搜索框，试试 Ctrl + S" : "Hide search box (Try Ctrl + S)";
-
-export {
-  keyText,
-  BestMatchTitle,
-  LastBestMatch,
-  BestMatch,
-  EmptyBookmarkMessage,
-  ShowSearchWrapper,
-  HideSearchWrapper,
-};
+export { keyText, BestMatchTitle, LastBestMatch, BestMatch, EmptyBookmarkMessage };

--- a/bookmark/utils/notification.js
+++ b/bookmark/utils/notification.js
@@ -1,31 +1,30 @@
+// Cached container — DOM lookup per show/hide is wasteful
+let _container = null;
+function getContainer() {
+  if (_container && _container.isConnected) return _container;
+  _container = document.querySelector("#notification-container");
+  return _container;
+}
+
 export const Notification = {
   timer: null,
-  /**
-   * 展示 notification
-   * @param {string} message notification message
-   * @param {boolean} hideTime auto hide time
-   */
   show(message, hideTime = 0) {
-    const container = document.querySelector("#notification-container");
-    container.style.transform = `translateX(-105%)`;
+    const container = getContainer();
+    if (!container) return;
     container.textContent = message;
-    container.style.transform = `translateX(0)`;
+    container.classList.add("show");
     if (hideTime > 0) {
-      if (this.timer) {
-        clearTimeout(this.timer);
-      }
+      if (this.timer) clearTimeout(this.timer);
       this.timer = setTimeout(() => {
         clearTimeout(this.timer);
+        this.timer = null;
         this.hide();
       }, hideTime);
     }
   },
-  /**
-   * 移除 notification
-   *
-   */
   hide() {
-    const container = document.querySelector("#notification-container");
-    container.style.transform = `translateX(-105%)`;
+    const container = getContainer();
+    if (!container) return;
+    container.classList.remove("show");
   },
 };


### PR DESCRIPTION
## Overview

This PR introduces **Maple Bookmarks v2.0**, a major release adding browser sidebar (side panel) support with mutually exclusive popup/sidebar modes, an in-app settings overlay, a refreshed visual theme, and a substantial search performance rewrite. All existing popup behaviour is preserved; sidebar is opt-in via a new toggle.

## Highlights

### 🪟 Sidebar mode (Chrome side_panel + Firefox sidebar_action)
- New `sidebar.html` shares the same script and theme as `popup.html` so behaviour stays identical between the two surfaces.
- A new `background.js` service worker keeps the two modes mutually exclusive:
  - `chrome.action.setPopup({ popup: \"\" })` + `chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })` when sidebar is active.
  - The opposite when popup is active.
- Mode is persisted in `chrome.storage.local` so it survives browser restarts (`chrome.runtime.onStartup` re-applies it).
- A small mode-switch button (▤ / 🪟) lives next to the existing settings cog. Sidebar→popup uses `chrome.action.openPopup()` first (Chrome 127+) and falls back to a positioned `chrome.windows.create({ type: \"popup\" })` placed near the toolbar icon for older Chrome versions.
- A `chrome.storage.onChanged` listener auto-closes the stale panel when the mode changes from any surface, so popup and sidebar can never be visible at the same time.
- Firefox: `manifest_firefox.json` adds `sidebar_action` with `default_panel: \"sidebar.html\"` and an event-page background script. `globalThis.browser?.sidebarAction.open()/close()` is used as a fallback path where `chrome.sidePanel` is unavailable.

### ⚙️ Settings as in-app overlay
- The settings cog no longer opens a separate options tab; it slides an overlay into the popup or sidebar with the same toggles plus the new Display Mode switch.
- Toggles bind directly to `localStorage` (and `chrome.storage.local` for display mode) and apply immediately. Toggling Search reloads the surface so the input listener is re-bound; toggling Display Mode reuses the mode-switch flow with the popup-window fallback.
- ESC closes the overlay. EN/ZH copy is included.
- The existing `settings.html` is kept so users who reach options via `chrome://extensions` still have a working page; the in-app surface is the primary entry point.

### 🎨 Visual refresh (shared `theme.css`)
- Warm maple palette with CSS variables (`--maple-accent`, `--maple-card`, `--maple-shadow-*`, etc.) and a matching dark mode.
- Cards: 10px radius, subtle 1px border, soft shadow, hover lift + accent glow.
- Folder titles are uppercase secondary-tone with an accent hover; collapsible folder rows pick up an accent background.
- Floating tooltip redesigned to a centred pill with `backdrop-filter: blur` and a fade-up transition (replaces the slide-in toast).
- Settings/mode buttons are always visible at low opacity and brighten on hover/focus.
- `popup.html` and `sidebar.html` only carry layout-specific CSS (fixed vs fluid sizing); everything else lives in `theme.css` to eliminate the previous duplication.

### 🔍 Search bar always visible & performance rewrite
- Search bar is now permanently visible in both popup and sidebar (when search is enabled). The hot-area + collapse arrow toggle is hidden via `display: none !important` and the Ctrl+S handler simply focuses the input.
- The single biggest perf win: the input handler used to construct **a new Fuse instance for every bookmark on every keystroke** (effectively O(n²)). It now builds **one cached Fuse instance per render** and runs a single search per keystroke.
- A bookmark cache (`getBookmarkCache`) is built lazily on first search and invalidated only when bookmarks are re-rendered. Each cached item also carries its precomputed ancestor folder chain so nested folders correctly stay visible when a descendant matches.
- Bookmark rendering uses a `DocumentFragment` so the bookmark tree is attached in a single DOM operation instead of one append per item.
- Notification container reference is cached (with `isConnected` guard) instead of being queried on every `show/hide`.
- Search debounce raised from 30ms → 80ms now that each keystroke does meaningfully less work.

### 🐛 Bugs fixed along the way
- **CSP violation**: the original sidebar bootstrap used an inline `<script>window.MAPLE_MODE = \"sidebar\"</script>`, which MV3's default CSP blocks. Mode is now derived from `location.pathname` (`/sidebar\\.html$/`).
- **Stuck on sidebar**: `chrome.action.openPopup()` was sometimes silently failing; the popup-window fallback positions a 420×560 popup near the toolbar icon so the switch always succeeds.
- **Ctrl+S in popup**: previously toggled `searchIsHide` and could hide the bar even though search is meant to be permanent. It now just focuses the input.
- **Nested folder filtering**: the search filter only marked the immediate parent folder visible, hiding ancestors and breaking nested matches. The cache now stores the precomputed ancestor chain.
- **Best-match cache pollution**: `getElementsByClassName(.bookmark)` previously included the dynamic `#best-match` items, leaving cached references stale after each search. The cache is now scoped to `#bookmarks`.

### 🧹 Dead code removed (~70 lines)
`switchSearchBarShowStatus`, `bindSwitchModeToFirstFolder`, the per-bookmark `FuseStrMatch`, `hideArrow`/`hideArrowIcon`/`hasBoundHotAreaEvents` references, and the `ShowSearchWrapper`/`HideSearchWrapper` i18n strings are no longer needed and have been removed.

## Files changed
| File | Change |
| --- | --- |
| `bookmark/manifest.json` | Adds `side_panel`, `sidePanel`/`storage` permissions, `background.service_worker`, version → 2.0 |
| `bookmark/manifest_firefox.json` | Adds `sidebar_action` + event-page background; version → 2.0 |
| `bookmark/background.js` | New service worker for mode mutual exclusion |
| `bookmark/sidebar.html` | New responsive sidebar entry sharing `popup.js` and `theme.css` |
| `bookmark/popup.html` | Slimmed to layout-specific CSS; mode-switch button; settings overlay HTML |
| `bookmark/popup.js` | Fuse cache + DocumentFragment rendering; settings overlay; mode-switch flow; Ctrl+S → focus; URL-based mode detection |
| `bookmark/theme.css` | New shared theme |
| `bookmark/utils/notification.js` | Container caching, `.show` class API |
| `bookmark/utils/i18n.js` | Removed unused strings; defensive null-check on `searchInput` |
| `bookmark/settings.html` / `settings.js` | Adds Display Mode toggle; version bump |

## Compatibility
- **Chrome / Edge**: Full feature set (Chrome 116+ for `sidePanel`, 127+ preferred for `chrome.action.openPopup`; older versions fall back to a positioned popup window).
- **Firefox**: Sidebar opens via `sidebar_action`; the service worker uses event-page semantics. `chrome.sidePanel` calls are guarded so they no-op safely.
- **Manifest V3**: All scripts are external; the bootstrap respects the default CSP (no `unsafe-inline`).

## Test plan
- [ ] Load the unpacked extension in Chrome and confirm popup opens with the new theme.
- [ ] Open Settings → toggle Display Mode → sidebar opens, popup closes; toggle back → popup reopens (toolbar-anchored on Chrome 127+, positioned popup window otherwise).
- [ ] Confirm popup and sidebar are never visible simultaneously after toggling from either surface.
- [ ] Toggle Search → search bar appears at the top; type to filter; matches inside nested folders stay visible.
- [ ] Hover a long bookmark title → new pill tooltip appears at the bottom; mouse leaves → tooltip fades out.
- [ ] Press Ctrl/Cmd+S → search input is focused (does not hide).
- [ ] Press ESC → search clears; ESC inside settings overlay closes the overlay.
- [ ] Reload the browser → previously selected mode is restored automatically.
- [ ] Build packages with `npm run build` (no schema regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)